### PR TITLE
spec exposes trailing <li> bug

### DIFF
--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -77,8 +77,8 @@ describe RedCloth do
   end
 
   it "should not add spurious li tags to the end of markup" do
-    input         = "* one\n* two\n*thee \n\n"
-    failing_input = "* one\n* two\n*thee \n\n\n"
+    input         = "* one\n* two\n* three \n\n"
+    failing_input = "* one\n* two\n* three \n\n\n"
     RedCloth.new(input).to_html.should_not match /<li>$/
     RedCloth.new(failing_input).to_html.should_not match /<li>$/
   end


### PR DESCRIPTION
Hi I was noticing the following behavior, so I thought I would submit a test for it.  I hope it helps.

```
RedCloth.new("* one\n* two\n* three \n\n").to_html
# => "<ul>\n\t<li>one</li>\n\t<li>two</li>\n\t<li>three</li>\n</ul>"

RedCloth.new("* one\n* two\n* three \n\n\n").to_html
#=> "<ul>\n\t<li>one</li>\n\t<li>two</li>\n\t<li>three</li>\n</ul>\n<li>"
# note extra trailing <li> outside <ul>
```
