### PR TITLE
Double quotes in LaTeX text

### DIFF
--- a/lib/redcloth/formatters/latex.rb
+++ b/lib/redcloth/formatters/latex.rb
@@ -241,7 +241,7 @@ module RedCloth::Formatters::LATEX
   end
 
   def quote2(opts)
-    "``#{opts[:text]}\""
+    "``#{opts[:text]}''"
   end
 
   def ellipsis(opts)


### PR DESCRIPTION
The LaTeX formatter outputs smart quotes for the open of a double-quoted string, but not the close. This change makes all double quotes smart quotes.
