### PR TITLE
4.2.6 broken?

### DIFF
--- a/redcloth.gemspec
+++ b/redcloth.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables      = ['redcloth']
   s.extra_rdoc_files = ["README.rdoc", "COPYING", "CHANGELOG"]
   s.rdoc_options     = ["--charset=UTF-8", "--line-numbers", "--inline-source", "--title", "RedCloth", "--main", "README.rdoc"]
-  s.require_path     = ["lib", "lib/case_sensitive_require"]
+  s.require_paths   << "lib/case_sensitive_require"
 
   s.files -= Dir['lib/redcloth.jar']
   s.files -= Dir['lib/**/*.dll']


### PR DESCRIPTION
As far as I can tell 4.2.6 is inoperable.  A little digging revealed a gemspec semantic typo I believe.
