### PR TITLE
Spaces around en-dash in LaTeX

### DIFF
--- a/lib/redcloth/formatters/latex.rb
+++ b/lib/redcloth/formatters/latex.rb
@@ -253,7 +253,7 @@ module RedCloth::Formatters::LATEX
   end
 
   def endash(opts)
-    "--"
+    " -- "
   end
 
   def arrow(opts)

--- a/lib/redcloth/formatters/latex_entities.yml
+++ b/lib/redcloth/formatters/latex_entities.yml
@@ -28,9 +28,9 @@ mdash: ---
 #EM DASH
 "8212": ---
 #EN DASH
-ndash: --
+ndash: ' -- '
 #EN DASH
-"8211": --
+"8211": ' -- '
 #HYPHEN
 "8208": "-"
 #OPEN BOX

--- a/spec/fixtures/basic.yml
+++ b/spec/fixtures/basic.yml
@@ -173,7 +173,7 @@ name: single hyphens with spaces
 desc: Single hyphens are replaced with en-dashes if they are surrounded by spaces.
 in: Observe - tiny and brief.
 html: <p>Observe &#8211; tiny and brief.</p>
-latex: "Observe--tiny and brief.\n\n"
+latex: "Observe -- tiny and brief.\n\n"
 --- 
 name: midword hyphens 
 desc: Single hyphens are left alone if not surrounded by spaces.


### PR DESCRIPTION
The LaTeX formatter outputs en-dashes with no spaces around them. This change adds a space around the outputted en-dashes.
