### PR TITLE
Use RSTRING_NOT_MODIFIED header for Rubinius

### DIFF
--- a/ragel/redcloth_attributes.c.rl
+++ b/ragel/redcloth_attributes.c.rl
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2009 Jason Garber
  */
+#define RSTRING_NOT_MODIFIED
 #include <ruby.h>
 #include "redcloth.h"
 

--- a/ragel/redcloth_inline.c.rl
+++ b/ragel/redcloth_inline.c.rl
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2009 Jason Garber
  */
+#define RSTRING_NOT_MODIFIED
 #include <ruby.h>
 #include "redcloth.h"
 

--- a/ragel/redcloth_scan.c.rl
+++ b/ragel/redcloth_scan.c.rl
@@ -5,6 +5,7 @@
  */
 #define redcloth_scan_c
 
+#define RSTRING_NOT_MODIFIED
 #include <ruby.h>
 #include "redcloth.h"
 


### PR DESCRIPTION
I've added this #define so Rubinius doesn't try to keep the char\* cache that backs a String object in the C-Api in Rubinius in sync. This only works if a C extension doesn't directly modify the char\* buffer that for example RSTRING_PTR gives back.

I've found no such cases in RedCloth in a quick browse through the source, so I think it's safe. In order to know for sure, I'd like one of the authors to verify and confirm that indeed a char\* buffer returned from RSTRING_PTR is never directly modified. 

This change fixes a performance issue where generating documentation from a textile document went from minutes of runtime (spending all that time in keeping the char\* buffer and Rubinius' internal representation in sync) to a runtime of just a matter of seconds. 

Also see: https://github.com/rubinius/rubinius/issues/1124
