### PR TITLE
1.9.3/config update

### DIFF
--- a/lib/redcloth.rb
+++ b/lib/redcloth.rb
@@ -7,7 +7,7 @@ Object.send(:remove_const, :RedCloth) if Object.const_defined?(:RedCloth) && Red
 
 require 'rbconfig'
 begin
-  prefix = Config::CONFIG['arch'] =~ /mswin|mingw/ ? "#{Config::CONFIG['MAJOR']}.#{Config::CONFIG['MINOR']}/" : ''
+  prefix = RbConfig::CONFIG['arch'] =~ /mswin|mingw/ ? "#{Config::CONFIG['MAJOR']}.#{Config::CONFIG['MINOR']}/" : ''
   lib = "#{prefix}redcloth_scan"
   require lib
 rescue LoadError => e


### PR DESCRIPTION
Very small patch - just updates Config to RbConfig to remove a ruby 1.9.3 warning message.
