### PR TITLE
Fix RbConfig / Config warning in Ruby 1.9.3.

### DIFF
--- a/lib/redcloth.rb
+++ b/lib/redcloth.rb
@@ -7,7 +7,8 @@ Object.send(:remove_const, :RedCloth) if Object.const_defined?(:RedCloth) && Red
 
 require 'rbconfig'
 begin
-  prefix = Config::CONFIG['arch'] =~ /mswin|mingw/ ? "#{Config::CONFIG['MAJOR']}.#{Config::CONFIG['MINOR']}/" : ''
+  conf = Object.const_get(defined?(RbConfig) ? :RbConfig : :Config)::CONFIG
+  prefix = conf['arch'] =~ /mswin|mingw/ ? "#{conf['MAJOR']}.#{conf['MINOR']}/" : ''
   lib = "#{prefix}redcloth_scan"
   require lib
 rescue LoadError => e


### PR DESCRIPTION
"Config" is deprecated in Ruby 1.9.3, in favor of "RbConfig". This
patch uses whichever is available, preventing Ruby 1.9.3 from printing
a deprecation warning when redcloth is loaded.

This patch is similar to #10, but retains backwards compatibility with Ruby 1.9.2.
