### PR TITLE
Server mode for clean development

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -74,6 +74,10 @@ Multi-line example:
  EOD
  puts doc.to_html
 
+Alternatively, you may use the redcloth script as a server when writing
+a textile document by executing the following from the command line:
+
+  > redcloth --server Document.textile
 
 == What is Textile?
 

--- a/bin/redcloth
+++ b/bin/redcloth
@@ -2,6 +2,7 @@
 $:.unshift(File.dirname(__FILE__) + '/../lib/')
 require 'optparse'
 require 'redcloth'
+require 'webrick'
 
 if %w(--version -v).include? ARGV.first
   puts "#{RedCloth::NAME} #{RedCloth::VERSION}"
@@ -9,6 +10,7 @@ if %w(--version -v).include? ARGV.first
 end
 
 output_as = "html"
+server_mode, server_port = nil, 7013
 opts = OptionParser.new do |opts|
     opts.banner = "Usage: redcloth [options] [redcloth_formatted.txt]"
     opts.separator "If no file specified, STDIN will be used. If you are typing input, you can send an EOF by pressing ^D (^Z on Windows)"
@@ -16,13 +18,35 @@ opts = OptionParser.new do |opts|
     opts.on("-o", "--output STYLE", "Output format (defaults to #{output_as})") do |o|
         output_as = o
     end
+    opts.on("--server [PORT]", "Run in server mode (default port #{server_port})") do |port| 
+        server_mode = true
+        server_port = port.to_i unless port.nil? || port.to_i == 0
+    end
 end
 opts.parse! ARGV
 
-red = RedCloth.new( ARGF.read )
-out_meth = "to_#{ output_as }"
-if red.respond_to? out_meth
+if server_mode
+  class RedClothServlet < WEBrick::HTTPServlet::AbstractServlet
+    def do_GET(request, response)
+      contents = open(ARGV.first) { |f| f.read }
+      red = RedCloth.new(contents)
+      response['Content-Type'] = 'text/html'
+      response.body = red.to_html
+    end
+  end
+  server = WEBrick::HTTPServer.new(
+    :Port         => server_port
+  )
+  server.mount('/', RedClothServlet)
+  thread = Thread.new { server.start() }
+  trap("INT") { server.shutdown }
+  thread.join()
+else 
+  red = RedCloth.new( ARGF.read )
+  out_meth = "to_#{ output_as }"
+  if red.respond_to? out_meth
     puts red.method( out_meth ).call
-else
+  else
     abort "** No to_#{ output_as } method found for the `#{ output_as }' format"
+  end
 end


### PR DESCRIPTION
I typically use textile for my github projects. (Very) often, it is the case that I make some minor markup typo when writing my textile files and only notice them after I have commited the file and pushed it to github, where it is rendered on their website. 

This can be avoided by edit -> run the redcloth script -> view in browser -> (delete any files, if not piped) -> repeat cycle, but I'd like to avoid that. I submit this minor feature extension as a solution for people (like me) who want the easier edit cycle of run redcloth in server mode -> edit -> view in browser. 

I tried to adhere to your ruby style. I also edited the README to show how to start in server mode.

It has only been tested on my development machine: a Fedora 13, x86_64 computer with ruby 1.9.2p290.

Thanks for redcloth :)
