### PR TITLE
Lazily load latex_entities.yml

### DIFF
--- a/lib/redcloth/formatters/latex.rb
+++ b/lib/redcloth/formatters/latex.rb
@@ -3,7 +3,9 @@ require 'yaml'
 module RedCloth::Formatters::LATEX
   include RedCloth::Formatters::Base
 
-  ENTITIES = YAML::load(File.read(File.dirname(__FILE__)+'/latex_entities.yml'))
+  def self.entities
+    @entities ||= YAML.load(File.read(File.dirname(__FILE__)+'/latex_entities.yml'))
+  end
 
   module Settings
     # Maps CSS style names to latex formatting options
@@ -275,8 +277,8 @@ module RedCloth::Formatters::LATEX
   # TODO: what do we do with (unknown) unicode entities ? 
   #
   def entity(opts)
-    text = opts[:text][0..0] == '#' ? opts[:text][1..-1] : opts[:text] 
-    ENTITIES[text]
+    text = opts[:text][0..0] == '#' ? opts[:text][1..-1] : opts[:text]
+    RedCloth::Formatters::LATEX.entities[text]
   end
 
   def dim(opts)


### PR DESCRIPTION
Loading `latex_entities.yml` takes about 100-150ms. Since most users of this gem will never use the LATEX formatter, loading this file should be deferred until it actually needs to be loaded.
