### PR TITLE
added cross compiling with Ruby 2.0 (tested against mingw-w64 4.6.3 on Ubuntu 12.04)

### DIFF
--- a/patches/mingw-w64-4.6.3-ruby-1.8.6-p398.patch
+++ b/patches/mingw-w64-4.6.3-ruby-1.8.6-p398.patch
@@ -1,0 +1,148 @@
+diff --git a/configure.in b/configure.in
+index 608be5c..cfb81d3 100644
+--- a/configure.in
++++ b/configure.in
+@@ -122,7 +122,7 @@ if test "$fat_binary" != no; then
+ 
+     # /usr/lib/arch_tool -archify_list $TARGET_ARCHS
+     ARCH_FLAG=
+-    for archs in $TARGET_ARCHS 
++    for archs in $TARGET_ARCHS
+     do
+         ARCH_FLAG="$ARCH_FLAG -arch $archs"
+     done
+@@ -204,6 +204,9 @@ cygwin*|mingw*)
+ 		esac], [with_winsock2=no])
+ 	if test "$with_winsock2" = yes; then
+ 	  AC_DEFINE(USE_WINSOCK2)
++    COMMON_HEADERS="ws2tcpip.h winsock2.h windows.h"
++  else
++    COMMON_HEADERS="windows.h winsock.h"
+ 	fi
+     esac
+     : ${enable_shared=yes}
+@@ -349,7 +352,7 @@ AC_CHECK_DECLS([sys_nerr], [], [], [$ac_includes_default
+ #include <errno.h>])
+ 
+ dnl whether link libc_r or not
+-AC_ARG_WITH(libc_r, 
++AC_ARG_WITH(libc_r,
+ 	[  --with-libc_r           link libc_r if possible (FreeBSD only)], [
+ 	case $withval in
+ 	yes) with_libc_r=yes;;
+@@ -489,7 +492,7 @@ AC_CHECK_HEADERS(stdlib.h string.h unistd.h limits.h sys/file.h sys/ioctl.h sys/
+ 		 fcntl.h sys/fcntl.h sys/select.h sys/time.h sys/times.h sys/param.h\
+ 		 syscall.h pwd.h grp.h a.out.h utime.h memory.h direct.h sys/resource.h \
+ 		 sys/mkdev.h sys/utime.h netinet/in_systm.h float.h ieeefp.h pthread.h \
+-		 ucontext.h intrinsics.h)
++		 ucontext.h intrinsics.h time.h)
+ 
+ dnl Check additional types.
+ AC_CHECK_SIZEOF(rlim_t, 0, [
+@@ -514,6 +517,13 @@ AC_STRUCT_ST_BLKSIZE
+ AC_STRUCT_ST_BLOCKS
+ AC_STRUCT_ST_RDEV
+ 
++AC_CHECK_TYPES([struct timezone], [], [], [@%:@ifdef HAVE_TIME_H
++@%:@ include <time.h>
++@%:@endif
++@%:@ifdef HAVE_SYS_TIME_H
++@%:@ include <sys/time.h>
++@%:@endif])
++
+ dnl Checks for library functions.
+ AC_TYPE_GETGROUPS
+ AC_TYPE_SIGNAL
+@@ -697,7 +707,7 @@ main()
+ fi
+ 
+ AC_FUNC_GETPGRP
+-AC_FUNC_SETPGRP  
++AC_FUNC_SETPGRP
+ 
+ AC_C_BIGENDIAN
+ AC_C_CONST
+@@ -960,8 +970,8 @@ fi
+ dnl default value for $KANJI
+ DEFAULT_KCODE="KCODE_NONE"
+ 
+-AC_ARG_WITH(default-kcode, 
+-	[  --with-default-kcode=CODE specify default value for \$KCODE (utf8|euc|sjis|none)], 
++AC_ARG_WITH(default-kcode,
++	[  --with-default-kcode=CODE specify default value for \$KCODE (utf8|euc|sjis|none)],
+ 	[case $withval in
+ 	utf8) DEFAULT_KCODE="KCODE_UTF8";;
+ 	euc)  DEFAULT_KCODE="KCODE_EUC";;
+@@ -972,7 +982,7 @@ AC_ARG_WITH(default-kcode,
+ AC_DEFINE_UNQUOTED(DEFAULT_KCODE, $DEFAULT_KCODE)
+ 
+ dnl wheather use dln_a_out or not
+-AC_ARG_WITH(dln-a-out, 
++AC_ARG_WITH(dln-a-out,
+ 	[  --with-dln-a-out        use dln_a_out if possible], [
+ 	case $withval in
+ 	yes) with_dln_a_out=yes;;
+@@ -1189,7 +1199,7 @@ if test "$ac_cv_header_a_out_h" = yes; then
+ #define USE_DLN_A_OUT
+ #include "dln.c"
+ ],
+-	[], 
++	[],
+ 	rb_cv_dln_a_out=yes,
+ 	rb_cv_dln_a_out=no)])
+     if test "$rb_cv_dln_a_out" = yes; then
+@@ -1537,7 +1547,6 @@ case "$target_os" in
+ 	    AC_LIBOBJ([win32])
+ 	    COMMON_LIBS=m
+ #	    COMMON_MACROS="WIN32_LEAN_AND_MEAN="
+-	    COMMON_HEADERS="windows.h winsock.h"
+ 	    ;;
+ 	esac
+ 	LIBRUBY_DLDFLAGS="${DLDFLAGS}"' -Wl,--out-implib=$(LIBRUBY)'
+diff --git a/missing.h b/missing.h
+index 4d54d4a..1cc78d2 100644
+--- a/missing.h
++++ b/missing.h
+@@ -25,6 +25,13 @@ struct timeval {
+ #  include <sys/types.h>
+ #endif
+ 
++#if !defined(HAVE_STRUCT_TIMEZONE)
++struct timezone {
++    int tz_minuteswest;
++    int tz_dsttime;
++};
++#endif
++
+ #ifndef HAVE_ACOSH
+ extern double acosh _((double));
+ extern double asinh _((double));
+diff --git a/win32/win32.h b/win32/win32.h
+index d3cd0ee..0b72f12 100644
+--- a/win32/win32.h
++++ b/win32/win32.h
+@@ -78,6 +78,10 @@ extern "C++" {
+ }
+ #endif
+ 
++#ifdef HAVE_UNISTD_H
++# include <unistd.h>
++#endif
++
+ #ifdef _M_IX86
+ # define WIN95 1
+ #else
+@@ -155,11 +159,9 @@ extern DWORD rb_w32_osid(void);
+ #undef unlink
+ #define unlink(p)		rb_w32_unlink(p)
+ 
++struct timezone;
++
+ #ifdef __MINGW32__
+-struct timezone {
+-  int tz_minuteswest;
+-  int tz_dsttime;
+-};
+ #undef isascii
+ #define isascii __isascii
+ #endif

--- a/patches/mingw-w64-4.6.3-ruby-1.9.1-p243.patch
+++ b/patches/mingw-w64-4.6.3-ruby-1.9.1-p243.patch
@@ -1,0 +1,130 @@
+diff --git a/configure.in b/configure.in
+index e61b634..a118498 100644
+--- a/configure.in
++++ b/configure.in
+@@ -708,6 +708,13 @@ AC_CHECK_TYPES([struct timespec], [], [], [@%:@ifdef HAVE_TIME_H
+ @%:@include <time.h>
+ @%:@endif])
+
++AC_CHECK_TYPES([struct timezone], [], [], [@%:@ifdef HAVE_TIME_H
++@%:@ include <time.h>
++@%:@endif
++@%:@ifdef HAVE_SYS_TIME_H
++@%:@ include <sys/time.h>
++@%:@endif])
++
+ AC_CHECK_TYPE(fd_mask, [AC_DEFINE(HAVE_RB_FD_INIT, 1)])
+
+ dnl RUBY_DEFINT TYPENAME, SIZE, [SIGNED-OR-UNSIGNED], [INCLUDES = DEFAULT-INCLUDES]
+@@ -799,6 +806,7 @@ AC_REPLACE_FUNCS(dup2 memmove strerror\
+                  strlcpy strlcat)
+ AC_CHECK_FUNCS(fmod killpg wait4 waitpid fork spawnv syscall chroot fsync getcwd eaccess\
+ 	      truncate ftruncate chsize times utimes utimensat fcntl lockf lstat\
++        truncate64 ftruncate64 ftello64 fseeko fseeko64 \
+ 	      link symlink readlink\
+ 	      setitimer setruid seteuid setreuid setresuid setproctitle socketpair\
+ 	      setrgid setegid setregid setresgid issetugid pause lchown lchmod\
+diff --git a/include/ruby/missing.h b/include/ruby/missing.h
+index 71cb000..2c1c6d0 100644
+--- a/include/ruby/missing.h
++++ b/include/ruby/missing.h
+@@ -38,6 +38,13 @@ struct timespec {
+ };
+ #endif
+
++#if !defined(HAVE_STRUCT_TIMEZONE)
++struct timezone {
++    int tz_minuteswest;
++    int tz_dsttime;
++};
++#endif
++
+ #ifndef RUBY_EXTERN
+ #define RUBY_EXTERN extern
+ #endif
+diff --git a/include/ruby/win32.h b/include/ruby/win32.h
+index 46388a3..5b57ca4 100644
+--- a/include/ruby/win32.h
++++ b/include/ruby/win32.h
+@@ -88,6 +88,9 @@ typedef unsigned int uintptr_t;
+ #ifndef __MINGW32__
+ # define mode_t int
+ #endif
++#ifdef HAVE_UNISTD_H
++# include <unistd.h>
++#endif
+
+ #ifdef _M_IX86
+ # define WIN95 1
+@@ -179,7 +182,9 @@ extern DWORD rb_w32_osid(void);
+ #define stati64(path, st) rb_w32_stati64(path, st)
+ #elif !defined(_MSC_VER) || _MSC_VER < 1400
+ #define stati64 _stati64
++#ifndef _stati64
+ #define _stati64(path, st) rb_w32_stati64(path, st)
++#endif
+ #else
+ #define stati64 _stat64
+ #define _stat64(path, st) rb_w32_stati64(path, st)
+@@ -195,11 +200,9 @@ extern int rb_w32_fstat(int, struct stat *);
+ #define strncasecmp		strnicmp
+ #define fsync			_commit
+
++struct timezone;
++
+ #ifdef __MINGW32__
+-struct timezone {
+-  int tz_minuteswest;
+-  int tz_dsttime;
+-};
+ #undef isascii
+ #define isascii __isascii
+ #endif
+@@ -337,10 +340,43 @@ extern FILE *rb_w32_fsopen(const char *, const char *, int);
+ //
+
+ #define SUFFIX
+-extern int       truncate(const char *path, off_t length);
+-extern int       ftruncate(int fd, off_t length);
+-extern int       fseeko(FILE *stream, off_t offset, int whence);
+-extern off_t     ftello(FILE *stream);
++
++extern int   rb_w32_ftruncate(int fd, off_t length);
++extern int   rb_w32_truncate(const char *path, off_t length);
++extern off_t   rb_w32_ftello(FILE *stream);
++extern int   rb_w32_fseeko(FILE *stream, off_t offset, int whence);
++
++#undef HAVE_FTRUNCATE
++#define HAVE_FTRUNCATE 1
++#if defined HAVE_FTRUNCATE64
++#define ftruncate ftruncate64
++#else
++#define ftruncate rb_w32_ftruncate
++#endif
++
++#undef HAVE_TRUNCATE
++#define HAVE_TRUNCATE 1
++#if defined HAVE_TRUNCATE64
++#define truncate truncate64
++#else
++#define truncate rb_w32_truncate
++#endif
++
++#undef HAVE_FSEEKO
++#define HAVE_FSEEKO 1
++#if defined HAVE_FSEEKO64
++#define fseeko fseeko64
++#else
++#define fseeko rb_w32_fseeko
++#endif
++
++#undef HAVE_FTELLO
++#define HAVE_FTELLO 1
++#if defined HAVE_FTELLO64
++#define ftello ftello64
++#else
++#define ftello rb_w32_ftello
++#endif
+
+ //
+ // stubs

--- a/tasks/gems.rake
+++ b/tasks/gems.rake
@@ -9,16 +9,18 @@ namespace :build do
   You must install Windows rubies to ~/.rake-compiler with:
 
     rake-compiler cross-ruby VERSION=1.8.6-p398
-    # (Later 1.9.1 patch levels don't compile on mingw) 
+    # (Later 1.9.1 patch levels don't compile on mingw)
     rake-compiler cross-ruby VERSION=1.9.1-p243
+    rake-compiler cross-ruby VERSION=2.0.0-p195
   EOM
         exit(1)
       end
       # rvm and mingw ruby versions have to match to avoid errors
       sh "rvm ruby-1.8.6-p398@redcloth rake cross compile RUBY_CC_VERSION=1.8.6"
       sh "rvm ruby-1.9.1-p243@redcloth rake cross compile RUBY_CC_VERSION=1.9.1"
+      sh "rvm ruby-2.0.0-p195@redcloth rake cross compile RUBY_CC_VERSION=2.0.0"
       # This will copy the .so files to the proper place
-      sh "rake cross native gem RUBY_CC_VERSION=1.8.6:1.9.1"
+      sh "rake cross native gem RUBY_CC_VERSION=1.8.6:1.9.1:2.0.0"
     end
 
     desc 'Generate JRuby binary gem'


### PR DESCRIPTION
This is to enable the use of Ruby 2.0 on Windows without having to vendor the mingw binary.

I have also added the patches needed for cross-compiling 1.8.6 and 1.9.1 against the same mingw version. Refer to [this gist](https://gist.github.com/prusswan/8246120) for the list of official backports contained in the patches.