### PR TITLE
please include fix for CVE-2012-6684

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@
   * vulnerability reported by [Kousuke Ebihara] 
     * see http://co3k.org/blog/redcloth-unfixed-xss-en
 
-== 4.2.9 / November 25, 2011
+== 4.2.9.1 / February 24, 2015
 
 * Lazy-load latex_entities.yml [Charlie Somerville]
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,13 @@
 == Head
 
+* include CVE-2012-6684 fix [Tomas Pospisek]
+  * fix by [Antonio Terceiro] 
+    * see http://sources.debian.net/src/ruby-redcloth/4.2.9-4/debian/patches/0001-Filter-out-javascript-links-when-using-filter_html-o.patch/
+  * vulnerability reported by [Kousuke Ebihara] 
+    * see http://co3k.org/blog/redcloth-unfixed-xss-en
+
+== 4.2.9 / November 25, 2011
+
 * Lazy-load latex_entities.yml [Charlie Somerville]
 
 == 4.2.9 / November 25, 2011

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,3 +1,11 @@
+= Specifics of this RedCloth fork
+
+This RedCloth fork fixes CVE-2012-6684 as
+{reported by Kousuke Ebihara}(http://co3k.org/blog/redcloth-unfixed-xss-en)
+using a {patch by Antonio Terceiro}(http://sources.debian.net/src/ruby-redcloth/4.2.9-4/debian/patches/0001-Filter-out-javascript-links-when-using-filter_html-o.patch/)
+
+Read on below for the original RedCloth documentation
+
 = RedCloth - Textile parser for Ruby
 
 Homepage::  http://redcloth.org

--- a/lib/redcloth/formatters/html.rb
+++ b/lib/redcloth/formatters/html.rb
@@ -111,7 +111,11 @@ module RedCloth::Formatters::HTML
   end
   
   def link(opts)
-    "<a href=\"#{escape_attribute opts[:href]}\"#{pba(opts)}>#{opts[:name]}</a>"
+    if (filter_html || sanitize_html) && opts[:href] =~ /^\s*javascript:/
+      opts[:name]
+    else
+      "<a href=\"#{escape_attribute opts[:href]}\"#{pba(opts)}>#{opts[:name]}</a>"
+    end
   end
   
   def image(opts)

--- a/lib/redcloth/version.rb
+++ b/lib/redcloth/version.rb
@@ -3,7 +3,7 @@ module RedCloth
     MAJOR = 4
     MINOR = 2
     TINY  = 9
-    RELEASE_CANDIDATE = nil
+    RELEASE_CANDIDATE = 1
 
     STRING = [MAJOR, MINOR, TINY, RELEASE_CANDIDATE].compact.join('.')
     TAG = "REL_#{[MAJOR, MINOR, TINY, RELEASE_CANDIDATE].compact.join('_')}".upcase.gsub(/\.|-/, '_')

--- a/spec/security/CVE-2012-6684_spec.rb
+++ b/spec/security/CVE-2012-6684_spec.rb
@@ -1,0 +1,14 @@
+# https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-6684
+
+require 'redcloth'
+
+describe 'CVE-2012-6684' do
+
+  it 'should not let javascript links pass through' do
+    # PoC from http://co3k.org/blog/redcloth-unfixed-xss-en
+    output = RedCloth.new('["clickme":javascript:alert(%27XSS%27)]', [:filter_html, :filter_styles, :filter_classes, :filter_ids]).to_html
+    expect(output).to_not match(/href=.javascript:alert/)
+  end
+
+
+end


### PR DESCRIPTION
Hello,

I've included the patch for CVE-2012-6684 in my fork of redcloth, please include it.

But before pulling, please have a look at it first - there's additional random noise in it - as f.ex. in the README.rdoc that explains what this fork is for, and my slightly unusual versioning which you might not want to pull.

Thanks,
*t 