### PR TITLE
Update CI Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,26 @@
 language: ruby
+cache: bundler
+sudo: false
 rvm:
   - 2.0.0
   - 1.9.3
   - 1.9.2
   - jruby-18mode
   - jruby-19mode
-  - rbx-2.1.1
+  - rbx-2
   - ruby-head
   - jruby-head
   - 1.8.7
   - ree
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: jruby-18mode
+    - rvm: jruby-19mode
+    - rvm: jruby-head
 compiler:
   - clang
   - gcc
 before_script:
-  - rake clobber
+  - bundle update
+  - bundle exec rake clobber

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -6,13 +6,13 @@ describe RedCloth do
     it "should accept options" do
       lambda {
         RedCloth.new("test", [:hard_breaks])
-      }.should_not raise_error(ArgumentError)
+      }.should_not raise_error
     end
   end
   
   it "should have a VERSION" do
-    RedCloth.const_defined?("VERSION").should be_true
-    RedCloth::VERSION.const_defined?("STRING").should be_true
+    RedCloth.const_defined?("VERSION").should be_truthy
+    RedCloth::VERSION.const_defined?("STRING").should be_truthy
   end
   
   it "should show the version as a string" do
@@ -21,7 +21,7 @@ describe RedCloth do
   end
   
   it "should have EXTENSION_LANGUAGE" do
-    RedCloth.const_defined?("EXTENSION_LANGUAGE").should be_true
+    RedCloth.const_defined?("EXTENSION_LANGUAGE").should be_truthy
     RedCloth::EXTENSION_LANGUAGE.should_not be_empty
     RedCloth::DESCRIPTION.should include(RedCloth::EXTENSION_LANGUAGE)
   end


### PR DESCRIPTION
Removed `Deprecation Warnings` and updated tests to run on Travis's new infrastructure.

Tests are still failing on JRuby, that hasn't changed :disappointed: