### PR TITLE
Fix URL fragment handling

### DIFF
--- a/lib/redcloth/formatters/latex.rb
+++ b/lib/redcloth/formatters/latex.rb
@@ -198,7 +198,7 @@ module RedCloth::Formatters::LATEX
 
   # links
   def link(opts)
-    "\\href{#{opts[:href]}}{#{opts[:name]}}"
+    "\\href{#{opts[:href].sub!(/#/, '\#')}}{#{opts[:name]}}"
   end
   
   # FIXME: use includegraphics with security verification


### PR DESCRIPTION
`#` is a special character in latex so it must be escaped.