### PR TITLE
Immutable strings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require 'rubygems'
 require 'bundler'
-ENV['RUBYOPT'] = nil # Necessary to prevent Bundler from *&^%$#ing up rake-compiler.
 
 require 'rake/clean'
 

--- a/lib/redcloth/formatters/base.rb
+++ b/lib/redcloth/formatters/base.rb
@@ -28,6 +28,7 @@ module RedCloth::Formatters
       opts.delete(:class) if filter_classes
       opts.delete(:id) if filter_ids
 
+      atts = ''.dup
       opts[:"text-align"] = opts.delete(:align)
       opts[:style] += ';' if opts[:style] && (opts[:style][-1..-1] != ';')
       [:float, :"text-align", :"vertical-align"].each do |a|
@@ -36,10 +37,10 @@ module RedCloth::Formatters
       [:"padding-right", :"padding-left"].each do |a|
         opts[:style] = "#{a}:#{opts[a]}em;#{opts[:style]}" if opts[a]
       end
-      atts = [:style, :class, :lang, :id, :colspan, :rowspan, :title, :start, :align].map do |a|
-        " #{a}=\"#{ html_esc(opts[a].to_s, :html_escape_attributes) }\"" if opts[a]
+      [:style, :class, :lang, :id, :colspan, :rowspan, :title, :start, :align].each do |a|
+        atts << " #{a}=\"#{ html_esc(opts[a].to_s, :html_escape_attributes) }\"" if opts[a]
       end
-      atts.compact.join
+      atts
     end
     
     def method_missing(method, opts)

--- a/lib/redcloth/formatters/base.rb
+++ b/lib/redcloth/formatters/base.rb
@@ -28,7 +28,6 @@ module RedCloth::Formatters
       opts.delete(:class) if filter_classes
       opts.delete(:id) if filter_ids
 
-      atts = ''
       opts[:"text-align"] = opts.delete(:align)
       opts[:style] += ';' if opts[:style] && (opts[:style][-1..-1] != ';')
       [:float, :"text-align", :"vertical-align"].each do |a|
@@ -37,10 +36,10 @@ module RedCloth::Formatters
       [:"padding-right", :"padding-left"].each do |a|
         opts[:style] = "#{a}:#{opts[a]}em;#{opts[:style]}" if opts[a]
       end
-      [:style, :class, :lang, :id, :colspan, :rowspan, :title, :start, :align].each do |a|
-        atts << " #{a}=\"#{ html_esc(opts[a].to_s, :html_escape_attributes) }\"" if opts[a]
+      atts = [:style, :class, :lang, :id, :colspan, :rowspan, :title, :start, :align].map do |a|
+        " #{a}=\"#{ html_esc(opts[a].to_s, :html_escape_attributes) }\"" if opts[a]
       end
-      atts
+      atts.compact.join
     end
     
     def method_missing(method, opts)

--- a/lib/redcloth/formatters/latex.rb
+++ b/lib/redcloth/formatters/latex.rb
@@ -165,7 +165,7 @@ module RedCloth::Formatters::LATEX
 
   # FIXME: need caption and label elements similar to image -> figure
   def table_close(opts)
-    output = ["\\begin{table}\n"]
+    output  = "\\begin{table}\n".dup
     output << "  \\centering\n"
     output << "  \\begin{tabular}{ #{"l " * @table[0].size }}\n"
     @table.each do |row|
@@ -173,7 +173,7 @@ module RedCloth::Formatters::LATEX
     end
     output << "  \\end{tabular}\n"
     output << "\\end{table}\n"
-    output.join
+    output
   end
 
   # code blocks

--- a/lib/redcloth/formatters/latex.rb
+++ b/lib/redcloth/formatters/latex.rb
@@ -165,7 +165,7 @@ module RedCloth::Formatters::LATEX
 
   # FIXME: need caption and label elements similar to image -> figure
   def table_close(opts)
-    output  = "\\begin{table}\n"
+    output = ["\\begin{table}\n"]
     output << "  \\centering\n"
     output << "  \\begin{tabular}{ #{"l " * @table[0].size }}\n"
     @table.each do |row|
@@ -173,7 +173,7 @@ module RedCloth::Formatters::LATEX
     end
     output << "  \\end{tabular}\n"
     output << "\\end{table}\n"
-    output
+    output.join
   end
 
   # code blocks

--- a/spec/custom_tags_spec.rb
+++ b/spec/custom_tags_spec.rb
@@ -4,31 +4,31 @@ module FigureTag
   def fig( opts )
     label, img = opts[:text].split('|').map! {|str| str.strip}
 
-    html  = %Q{<div class="img" id="figure-#{label.tr('.', '-')}">\n}
-    html += %Q{  <a class="fig" href="/images/#{img}">\n}
-    html += %Q{    <img src="/images/thumbs/#{img}" alt="Figure #{label}" />\n}
-    html += %Q{  </a>\n}
-    html += %Q{  <p>Figure #{label}</p>\n}
-    html += %Q{<div>\n}
+    html  = %Q{<div class="img" id="figure-#{label.tr('.', '-')}">\n}.dup
+    html << %Q{  <a class="fig" href="/images/#{img}">\n}
+    html << %Q{    <img src="/images/thumbs/#{img}" alt="Figure #{label}" />\n}
+    html << %Q{  </a>\n}
+    html << %Q{  <p>Figure #{label}</p>\n}
+    html << %Q{<div>\n}
   end
 end
 
 describe "custom tags" do
   it "should recognize the custom tag" do
-    input  = %Q{The first line of text.\n\n}
-    input += %Q{fig. 1.1 | img.jpg\n\n}
-    input += %Q{The last line of text.\n}
+    input  = %Q{The first line of text.\n\n}.dup
+    input << %Q{fig. 1.1 | img.jpg\n\n}
+    input << %Q{The last line of text.\n}
     r = RedCloth.new input
     r.extend FigureTag
 
-    html  = %Q{<p>The first line of text.</p>\n}
-    html += %Q{<div class="img" id="figure-1-1">\n}
-    html += %Q{  <a class="fig" href="/images/img.jpg">\n}
-    html += %Q{    <img src="/images/thumbs/img.jpg" alt="Figure 1.1" />\n}
-    html += %Q{  </a>\n}
-    html += %Q{  <p>Figure 1.1</p>\n}
-    html += %Q{<div>\n}
-    html += %Q{<p>The last line of text.</p>}
+    html  = %Q{<p>The first line of text.</p>\n}.dup
+    html << %Q{<div class="img" id="figure-1-1">\n}
+    html << %Q{  <a class="fig" href="/images/img.jpg">\n}
+    html << %Q{    <img src="/images/thumbs/img.jpg" alt="Figure 1.1" />\n}
+    html << %Q{  </a>\n}
+    html << %Q{  <p>Figure 1.1</p>\n}
+    html << %Q{<div>\n}
+    html << %Q{<p>The last line of text.</p>}
     
     r.to_html.should == html
   end

--- a/spec/custom_tags_spec.rb
+++ b/spec/custom_tags_spec.rb
@@ -5,30 +5,30 @@ module FigureTag
     label, img = opts[:text].split('|').map! {|str| str.strip}
 
     html  = %Q{<div class="img" id="figure-#{label.tr('.', '-')}">\n}
-    html << %Q{  <a class="fig" href="/images/#{img}">\n}
-    html << %Q{    <img src="/images/thumbs/#{img}" alt="Figure #{label}" />\n}
-    html << %Q{  </a>\n}
-    html << %Q{  <p>Figure #{label}</p>\n}
-    html << %Q{<div>\n}
+    html += %Q{  <a class="fig" href="/images/#{img}">\n}
+    html += %Q{    <img src="/images/thumbs/#{img}" alt="Figure #{label}" />\n}
+    html += %Q{  </a>\n}
+    html += %Q{  <p>Figure #{label}</p>\n}
+    html += %Q{<div>\n}
   end
 end
 
 describe "custom tags" do
   it "should recognize the custom tag" do
     input  = %Q{The first line of text.\n\n}
-    input << %Q{fig. 1.1 | img.jpg\n\n}
-    input << %Q{The last line of text.\n}
+    input += %Q{fig. 1.1 | img.jpg\n\n}
+    input += %Q{The last line of text.\n}
     r = RedCloth.new input
     r.extend FigureTag
 
     html  = %Q{<p>The first line of text.</p>\n}
-    html << %Q{<div class="img" id="figure-1-1">\n}
-    html << %Q{  <a class="fig" href="/images/img.jpg">\n}
-    html << %Q{    <img src="/images/thumbs/img.jpg" alt="Figure 1.1" />\n}
-    html << %Q{  </a>\n}
-    html << %Q{  <p>Figure 1.1</p>\n}
-    html << %Q{<div>\n}
-    html << %Q{<p>The last line of text.</p>}
+    html += %Q{<div class="img" id="figure-1-1">\n}
+    html += %Q{  <a class="fig" href="/images/img.jpg">\n}
+    html += %Q{    <img src="/images/thumbs/img.jpg" alt="Figure 1.1" />\n}
+    html += %Q{  </a>\n}
+    html += %Q{  <p>Figure 1.1</p>\n}
+    html += %Q{<div>\n}
+    html += %Q{<p>The last line of text.</p>}
     
     r.to_html.should == html
   end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -85,12 +85,8 @@ describe RedCloth do
   
   if RUBY_VERSION > "1.9.0"
     it "should preserve character encoding" do
-      if RUBY_VERSION > "2.3.0"
-        input = String.new("This is an ISO-8859-1 string", encoding: 'iso-8859-1')
-      else
-        input = "This is an ISO-8859-1 string"
-        input.force_encoding 'iso-8859-1'
-      end
+      input = "This is an ISO-8859-1 string".dup
+      input.force_encoding 'iso-8859-1'
 
       output = RedCloth.new(input).to_html
       
@@ -99,12 +95,8 @@ describe RedCloth do
     end
     
     it "should not raise ArgumentError: invalid byte sequence" do
-      if RUBY_VERSION > "2.3.0"
-        s = String.new("\xa3", encoding: 'iso-8859-1')
-      else
-        s = "\xa3"
-        s.force_encoding 'iso-8859-1'
-      end
+      s = "\xa3".dup
+      s.force_encoding 'iso-8859-1'
       lambda { RedCloth.new(s).to_html }.should_not raise_error
     end
   end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -85,8 +85,13 @@ describe RedCloth do
   
   if RUBY_VERSION > "1.9.0"
     it "should preserve character encoding" do
-      input = "This is an ISO-8859-1 string"
-      input.force_encoding 'iso-8859-1'
+      if RUBY_VERSION > "2.3.0"
+        input = String.new("This is an ISO-8859-1 string", encoding: 'iso-8859-1')
+      else
+        input = "This is an ISO-8859-1 string"
+        input.force_encoding 'iso-8859-1'
+      end
+
       output = RedCloth.new(input).to_html
       
       output.should == "<p>This is an <span class=\"caps\">ISO</span>-8859-1 string</p>"
@@ -94,8 +99,12 @@ describe RedCloth do
     end
     
     it "should not raise ArgumentError: invalid byte sequence" do
-      s = "\xa3"
-      s.force_encoding 'iso-8859-1'
+      if RUBY_VERSION > "2.3.0"
+        s = String.new("\xa3", encoding: 'iso-8859-1')
+      else
+        s = "\xa3"
+        s.force_encoding 'iso-8859-1'
+      end
       lambda { RedCloth.new(s).to_html }.should_not raise_error
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ def fixtures
   Dir[File.join(File.dirname(__FILE__), *%w[fixtures *.yml])].each do |testfile|
     testgroup = File.basename(testfile, '.yml')
     num = 0
-    YAML::load_documents(File.open(testfile)) do |doc|
+    YAML::load_stream(File.open(testfile)) do |doc|
       name = doc['name'] || num
       @fixtures["#{testgroup} #{name}"] = doc
       num += 1


### PR DESCRIPTION
This PR fixes the cases where RedCloth doesn't work when string immutability is set.

* Removes the line from Rakefile that sets RUBYOPT to allow setting string immutablity like so:
      RUBYOPT="--enable-frozen-string-literal" be rake
  (I kind of understand where this line came from but perhaps there is another way to achieve the same effect).

* Updates the code of RedCloth and specs to not mutate string literals.

Background: This PR came from https://github.com/pry/pry/issues/1625, via the build failures of coderay with string immutability set (https://travis-ci.org/rubychan/coderay/jobs/261625648).

I have not updated the Travis configuration to actually run with immutable strings, since tests will fail at the end due to RSpec mutating string literals.