### PR TITLE
Allow RedCloth to build & load with local Windows MinGW build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :compilation do
-  gem 'rvm', '~> 1.11.3.9'
-  gem 'rake-compiler', '~> 0.7.1'
+  gem('rvm', '~> 1.11.3.9') if /mingw|mswin/ !~ RUBY_PLATFORM
+  gem 'rake-compiler', '>= 0.7.1'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,10 @@ require 'rake/clean'
 if File.directory? "ragel"
   Bundler.setup
   Bundler::GemHelper.install_tasks
-  Dir['tasks/**/*.rake'].each { |rake| load File.expand_path(rake) }
+  Dir['tasks/**/*.rake'].each {|rake|
+    next if (/mingw|mswin/ =~ RUBY_PLATFORM && /rvm\.rake\Z/ =~ rake)
+    load File.expand_path(rake)
+  }
 else
   # Omit generation/compile tasks and dependencies. In a gem package 
   # we only need tasks and dependencies required for running specs.

--- a/lib/redcloth.rb
+++ b/lib/redcloth.rb
@@ -8,9 +8,19 @@ Object.send(:remove_const, :RedCloth) if Object.const_defined?(:RedCloth) && Red
 require 'rbconfig'
 begin
   conf = Object.const_get(defined?(RbConfig) ? :RbConfig : :Config)::CONFIG
-  prefix = conf['arch'] =~ /mswin|mingw/ ? "#{conf['MAJOR']}.#{conf['MINOR']}/" : ''
-  lib = "#{prefix}redcloth_scan"
-  require lib
+  if conf['arch'] =~ /mswin|mingw/
+    if File.exist? File.join(__dir__, "redcloth_scan.so")
+      # built locally
+      require "redcloth_scan"
+    else
+      # fat binary gem
+      prefix = conf['arch'] = "#{conf['MAJOR']}.#{conf['MINOR']}/"
+      lib = "#{prefix}redcloth_scan"
+      require lib
+    end
+  else
+    require "redcloth_scan"
+  end
 rescue LoadError => e
   e.message << %{\nCouldn't load #{lib}\nThe $LOAD_PATH was:\n#{$LOAD_PATH.join("\n")}}
   raise e
@@ -23,18 +33,18 @@ require 'redcloth/formatters/html'
 require 'redcloth/formatters/latex'
 
 module RedCloth
-  
+
   # A convenience method for creating a new TextileDoc. See
   # RedCloth::TextileDoc.
   def self.new( *args, &block )
     RedCloth::TextileDoc.new( *args, &block )
   end
-  
+
   # Include extension modules (if any) in TextileDoc.
   def self.include(*args)
     RedCloth::TextileDoc.send(:include, *args)
   end
-  
+
 end
 
 begin

--- a/redcloth.gemspec
+++ b/redcloth.gemspec
@@ -37,5 +37,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 2.4')
   s.add_development_dependency('diff-lcs', '~> 1.1.2')
 
+  # allows local mingw builds for RubyInstaller2 builds (ruby 2.4+)
+  if s.respond_to?(:metadata=)
+    s.metadata ||= {}
+    s.metadata["msys2_mingw_dependencies"] = "ragel"
+  end
+
   s.license = "MIT"
 end


### PR DESCRIPTION
Allows Windows [RubyInstaller2](https://github.com/oneclick/rubyinstaller2) builds (Ruby 2.4+) to compile & load RedCloth.

Fork [Travis](https://travis-ci.org/MSP-Greg/redcloth) passed.

Locally, I'm using `ruby 2.5.0dev (2017-10-08 trunk 60140) [x64-mingw32]`, and passing all tests.  I'll add appveyor.yml later.