### PR TITLE
avoid monkeypatching erb/util to map `t`  to `textilize` 

### DIFF
--- a/lib/redcloth.rb
+++ b/lib/redcloth.rb
@@ -23,23 +23,23 @@ require 'redcloth/formatters/html'
 require 'redcloth/formatters/latex'
 
 module RedCloth
-  
+
   # A convenience method for creating a new TextileDoc. See
   # RedCloth::TextileDoc.
   def self.new( *args, &block )
     RedCloth::TextileDoc.new( *args, &block )
   end
-  
+
   # Include extension modules (if any) in TextileDoc.
   def self.include(*args)
     RedCloth::TextileDoc.send(:include, *args)
   end
-  
+
 end
 
-begin
-  require 'erb'
-  require 'redcloth/erb_extension'
-  include ERB::Util
-rescue LoadError
-end
+# begin
+#   require 'erb'
+#   require 'redcloth/erb_extension'
+#   include ERB::Util
+# rescue LoadError
+# end


### PR DESCRIPTION
Not a good idea to do this by default. Should be opt-in