### PR TITLE
Bump RSpec dependency.

### DIFF
--- a/redcloth.gemspec
+++ b/redcloth.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('bundler', '> 1.3.4')
   s.add_development_dependency('rake', '~> 10.0.3')
-  s.add_development_dependency('rspec', '~> 2.4')
+  s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('diff-lcs', '~> 1.1.2')
 
   s.license = "MIT"


### PR DESCRIPTION
It seems that the test suite is passing with RSpec 3.9 just fine with the exception of one deprecation warning.