### PR TITLE
Stop checking for `main` function in `libc`

### DIFF
--- a/tasks/compile.rake
+++ b/tasks/compile.rake
@@ -29,7 +29,6 @@ require 'mkmf'
 CONFIG['warnflags'].gsub!(/-Wshorten-64-to-32/, '') if CONFIG['warnflags']
 $CFLAGS << ' -O0 -Wall ' if CONFIG['CC'] =~ /gcc/
 dir_config("redcloth_scan")
-have_library("c", "main")
 create_makefile("redcloth_scan")
       EOF
     end


### PR DESCRIPTION
It makes very little sense and the commit that introduced this never explained why it's doing it.

This cause compilation for fail is ruby was installed with the --disable-install-static-library flag.