### PR TITLE
Fix CVE-2023-31606 (ReDOS possible in the sanitize_html function)

### DIFF
--- a/lib/redcloth/formatters/html.rb
+++ b/lib/redcloth/formatters/html.rb
@@ -324,7 +324,7 @@ private
   # Clean unauthorized tags.
   def clean_html( text, allowed_tags = BASIC_TAGS )
     text.gsub!( /<!\[CDATA\[/, '' )
-    text.gsub!( /<(\/*)(?>[A-Za-z]\w*)([^>]*?)(\s?\/?)>/ ) do |m|
+    text.gsub!( /<(\/*)([A-Za-z]\w*+)([^>]*?)(\s?\/?)>/ ) do |m|
       raw = $~
       tag = raw[2].downcase
       if allowed_tags.has_key? tag

--- a/lib/redcloth/formatters/html.rb
+++ b/lib/redcloth/formatters/html.rb
@@ -324,7 +324,7 @@ private
   # Clean unauthorized tags.
   def clean_html( text, allowed_tags = BASIC_TAGS )
     text.gsub!( /<!\[CDATA\[/, '' )
-    text.gsub!( /<(\/*)([A-Za-z]\w*)([^>]*?)(\s?\/?)>/ ) do |m|
+    text.gsub!( /<(\/*)(?>[A-Za-z]\w*)([^>]*?)(\s?\/?)>/ ) do |m|
       raw = $~
       tag = raw[2].downcase
       if allowed_tags.has_key? tag


### PR DESCRIPTION
A potential fix for #73 (https://github.com/e23e/CVE-2023-31606#readme).

The use of a [possessive quantifier](https://docs.ruby-lang.org/en/master/regexp_rdoc.html#label-Greedy-2C+Lazy-2C+or+Possessive+Matching) effectively prevents backtracking in the second group (which matches the tag):

```ruby
    text.gsub!( /<(\/*)([A-Za-z]\w*+)([^>]*?)(\s?\/?)>/ ) do |m|
```

In this case, the `\w*+` part (and therefore, the whole group `([A-Za-z]\w*+)`) will not backtrack. The rest of this regex is not subject to ReDoS (it's linear). So, we can use this version; it should work in Ruby 1.9 and up.