### PR TITLE
redcloth.rb - fixup `require 'redcloth_scan'` (remove Windows code)

### DIFF
--- a/lib/redcloth.rb
+++ b/lib/redcloth.rb
@@ -5,14 +5,10 @@
 # appears to be fixed in Edge Rails [51e4106].
 Object.send(:remove_const, :RedCloth) if Object.const_defined?(:RedCloth) && RedCloth.is_a?(Class)
 
-require 'rbconfig'
 begin
-  conf = Object.const_get(defined?(RbConfig) ? :RbConfig : :Config)::CONFIG
-  prefix = conf['arch'] =~ /mswin|mingw/ ? "#{conf['MAJOR']}.#{conf['MINOR']}/" : ''
-  lib = "#{prefix}redcloth_scan"
-  require lib
+  require 'redcloth_scan'
 rescue LoadError => e
-  e.message << %{\nCouldn't load #{lib}\nThe $LOAD_PATH was:\n#{$LOAD_PATH.join("\n")}}
+  e.message << %{\nCouldn't load redcloth_scan\nThe $LOAD_PATH was:\n#{$LOAD_PATH.join("\n")}}
   raise e
 end
 
@@ -23,7 +19,7 @@ require 'redcloth/formatters/html'
 require 'redcloth/formatters/latex'
 
 module RedCloth
-  
+
   # A convenience method for creating a new TextileDoc. See
   # RedCloth::TextileDoc.
   def self.new( *args, &block )
@@ -34,7 +30,7 @@ module RedCloth
   def self.include(*args)
     RedCloth::TextileDoc.send(:include, *args)
   end
-  
+
 end
 
 begin


### PR DESCRIPTION
`redcloth.rb` loads `redcloth_scan`, and it has Windows specific code that assumes one has installed a 'pre-compiled' gem.

Building extension gems on Windows is something most users can accomplish, as publicly available Windows Ruby builds include a gcc toolchain.

I have some code that I normally run on Windows. It generates YARD documentation, and some of the doc'd repos have Textile files.  I noticed the issue when updating this gem, as I had forgotten that I hacked the older version...

JFYI, I also have updates that run Actions CI for Ubuntu, macOS, & WIndows, Ruby 2.4 thru head.

closes #51, closes #61, closes #62

