### PR TITLE
Update maintainer, scrub redcloth.org

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,14 +1,12 @@
 = RedCloth - Textile parser for Ruby
 
-Homepage::  http://redcloth.org
-Maintainer:: Joshua Siler https://github.com/joshuasiler
+Homepage::  https://github.com/jgarber/redcloth
+Maintainer:: Helio Cola https://github.com/heliocola
 Author::    Jason Garber
 Copyright:: (c) 2011 Jason Garber
 License::   MIT
 
-{<img src="https://travis-ci.org/jgarber/redcloth.svg" />}[https://travis-ci.org/jgarber/redcloth] {<img src="https://codeclimate.com/github/jgarber/redcloth/badges/gpa.svg" />}[https://codeclimate.com/github/jgarber/redcloth]
-
-(See http://redcloth.org/textile/ for a Textile reference.)
+{rdoc-image:https://codeclimate.com/github/jgarber/redcloth/badges/gpa.svg}[https://codeclimate.com/github/jgarber/redcloth]
 
 = RedCloth
 

--- a/lib/redcloth/version.rb
+++ b/lib/redcloth/version.rb
@@ -22,7 +22,7 @@ module RedCloth
   
   NAME = "RedCloth"
   GEM_NAME = NAME
-  URL  = "http://redcloth.org/"
+  URL  = "https://github.com/jgarber/redcloth"
   description = "Textile parser for Ruby."
 
   if RedCloth.const_defined?(:EXTENSION_LANGUAGE)

--- a/redcloth.gemspec
+++ b/redcloth.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Textile parser for Ruby."
   s.summary     = RedCloth::SUMMARY
   s.email       = "redcloth-upwards@rubyforge.org"
-  s.homepage    = "http://redcloth.org"
+  s.homepage    = "https://github.com/jgarber/redcloth"
   s.rubyforge_project = "redcloth"
 
   s.rubygems_version   = "1.3.7"


### PR DESCRIPTION
I've lost the domain redcloth.org after some 15 years. The site was hosted on a custom CMS written around 2008. Heroku was no longer supporting it.

Onward to things that others can maintain!