### PR TITLE
Update testing matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }})
     strategy:
       matrix:
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [3.0, 3.1, 3.2, 3.3, 3.4]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04, macos-12, macos-13, windows-2022 ]
-        ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, head ]
+        ruby: [ 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4, head ]
         include:
           - { os: windows-2022 , ruby: ucrt  }
           - { os: windows-2022 , ruby: mswin }


### PR DESCRIPTION
### What

This pull request:
- adds ruby 3.3, and 3.4 to the testing matrix
- removes ruby 2.7 from the testing matrix