### PR TITLE
Explain the difference between the gem name and the filename to be required

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 == 4.3.5
 
 * Add GitHub Actions - Ubuntu, macOS, & Windows, Ruby 2.4 thru head, misc updates [MSP-Greg]
+* Explain difference between gem name and filename to be required. [Stephan Kämper]
 
 == 4.3.4 / Mar 13th, 2024
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -49,7 +49,11 @@ RedCloth is simply an extension of the String class that can handle
 Textile formatting.  Use it like a String and output HTML with its
 RedCloth#to_html method.
 
+While the gem name is 'RedCloth', the filename to `require` is 'redcloth` (all lowercare letters).
+
 Simple use:
+ require 'redcloth'
+
  text = "This is *my* text."
  RedCloth.new(text).to_html
 


### PR DESCRIPTION
While I understand the difference between _gem names_ and the _corresponding file names_ that you require in Ruby code, I regularly struggle when actually using gems that have a difference in the capitalisation between the gem and the filename.

I figured that a short mention of this difference and the corresponding `require`in the short example might help others, too.