### PR TITLE
Rename COPYING to LICENSE.txt, update authorship and copyright

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,5 @@
 Copyright (c) 2011 Jason Garber
+Copyright (c) 2024-2026 Helio Cola
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -6,13 +7,13 @@ deal in the Software without restriction, including without limitation the
 rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 sell copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-  
+
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
-   
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,8 +2,6 @@
 
 Homepage::  https://github.com/jgarber/redcloth
 Maintainer:: Helio Cola https://github.com/heliocola
-Author::    Jason Garber
-Copyright:: (c) 2011 Jason Garber
 License::   MIT
 
 {rdoc-image:https://codeclimate.com/github/jgarber/redcloth/badges/gpa.svg}[https://codeclimate.com/github/jgarber/redcloth]
@@ -11,10 +9,6 @@ License::   MIT
 = RedCloth
 
 RedCloth is a Ruby library for converting Textile into HTML.
-
-== Attention - Deprecating JRuby and Windows support in version 4.3
-
-In order to prioritize merging a fix for the long standing vulnerability *CVE-2012-6684*, our {new maintainer}[https://github.com/joshuasiler] has elected to stop maintaining the precompiled versions for Windows and JRuby. 
 
 == Installing
 
@@ -26,7 +20,8 @@ RedCloth can be installed via RubyGems:
 
 If you just want to use RedCloth, you do NOT need to build/compile it. It is
 compiled from C sources automatically when you install the gem on the ruby
-platform. Precompiled binary gems are provided for JRuby and Win32 platforms prior to version 4.3.
+platform. Precompiled binary gems were provided for JRuby and Win32 platforms 
+prior to version 4.3, but now these platforms require compilation.
 
 RedCloth can be compiled with <tt>rake compile</tt>. Ragel 6.3 or greater is
 required. Again, Ragel is NOT needed to simply use RedCloth.


### PR DESCRIPTION
## Summary

- Rename `COPYING` to `LICENSE.txt` for GitHub license auto-detection
- Add Helio Cola as copyright holder from 2024
- Remove `Author` and `Copyright` fields from README
- Fold precompiled Windows and JRuby deprecation into the Compiling section

Made with [Cursor](https://cursor.com)